### PR TITLE
feat: #26 Adding custom styles for ExpressiveCode contents

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -63,6 +63,31 @@ export default defineConfig({
           titleClass: 'av-title',
         }),
       ],
+      expressiveCodeStyleOverrides: {
+        textMarkers: {
+          markHue({ theme }) {
+            return theme.type == 'dark' ? '359.59' : '69.68';
+          },
+          defaultChroma({ theme }) {
+            return theme.type == 'dark' ? '77.59' : '63.4';
+          },
+          defaultLuminance({ theme }) {
+            return theme.type == 'dark' ? '50.08' : '73.06'
+          },
+          backgroundOpacity: '15%'
+        },
+        collapsibleSections: {
+          closedBackgroundColor: 'var(--av-ec-collapsibleSections-closedBackgroundColor)',
+          closedTextColor: 'var(--av-ec-collapsibleSections-closedTextColor)',
+          openBackgroundColorCollapsible: 'var(--av-ec-collapsibleSections-openBackgroundColorCollapsible)'
+        },
+        frames: {
+          tooltipSuccessBackground: 'var(--tk-text-positive)',
+          tooltipSuccessForeground({ theme }) {
+            return theme.type == 'light' ? 'whitesmoke' : 'black'
+          }
+        }
+      }
     }),
   ],
 });

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "cookie-parser": "^1.4.7",
     "express": "^5.1.0",
     "hastscript": "^9.0.1",
-    "logos": "link:@iconify/json/logos",
     "prettier-plugin-astro": "^0.14.1",
     "react-tooltip": "^5.29.1",
     "rehype-autolink-headings": "^7.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,9 +106,6 @@ importers:
       hastscript:
         specifier: ^9.0.1
         version: 9.0.1
-      logos:
-        specifier: link:@iconify/json/logos
-        version: link:@iconify/json/logos
       prettier-plugin-astro:
         specifier: ^0.14.1
         version: 0.14.1
@@ -756,23 +753,14 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@expressive-code/core@0.35.6':
-    resolution: {integrity: sha512-xGqCkmfkgT7lr/rvmfnYdDSeTdCSp1otAHgoFS6wNEeO7wGDPpxdosVqYiIcQ8CfWUABh/pGqWG90q+MV3824A==}
-
   '@expressive-code/core@0.40.2':
     resolution: {integrity: sha512-gXY3v7jbgz6nWKvRpoDxK4AHUPkZRuJsM79vHX/5uhV9/qX6Qnctp/U/dMHog/LCVXcuOps+5nRmf1uxQVPb3w==}
 
   '@expressive-code/core@0.41.3':
     resolution: {integrity: sha512-9qzohqU7O0+JwMEEgQhnBPOw5DtsQRBXhW++5fvEywsuX44vCGGof1SL5OvPElvNgaWZ4pFZAFSlkNOkGyLwSQ==}
 
-  '@expressive-code/plugin-collapsible-sections@0.35.6':
-    resolution: {integrity: sha512-PciZoBynxp3DCrK3dvcc/rxkj2HVbFxX992yqez1pircmPj0g1STySslkOBVMHh9COy6whJ4Mbq2k9DPV1A5/Q==}
-
   '@expressive-code/plugin-collapsible-sections@0.41.3':
     resolution: {integrity: sha512-cuHIN7Ipl7gUcaWFfsgy6G3wn0Svk8dQ6WKXNQha63BURbm7CSBhD6y9qFGeIOrxaJtvH4Pj3Xb4C2Ni0OVwYA==}
-
-  '@expressive-code/plugin-frames@0.35.6':
-    resolution: {integrity: sha512-CqjSWjDJ3wabMJZfL9ZAzH5UAGKg7KWsf1TBzr4xvUbZvWoBtLA/TboBML0U1Ls8h/4TRCIvR4VEb8dv5+QG3w==}
 
   '@expressive-code/plugin-frames@0.40.2':
     resolution: {integrity: sha512-aLw5IlDlZWb10Jo/TTDCVsmJhKfZ7FJI83Zo9VDrV0OBlmHAg7klZqw68VDz7FlftIBVAmMby53/MNXPnMjTSQ==}
@@ -780,17 +768,11 @@ packages:
   '@expressive-code/plugin-frames@0.41.3':
     resolution: {integrity: sha512-rFQtmf/3N2CK3Cq/uERweMTYZnBu+CwxBdHuOftEmfA9iBE7gTVvwpbh82P9ZxkPLvc40UMhYt7uNuAZexycRQ==}
 
-  '@expressive-code/plugin-line-numbers@0.35.6':
-    resolution: {integrity: sha512-WVPk1ghCP1i1CfW4xDVQptlY1Py1X7u5tWhFZnLAvcuPtSo6iYP3DPOGtQpmrucnmvYIwWTdruiNFUlDUUIAcQ==}
-
-  '@expressive-code/plugin-shiki@0.35.6':
-    resolution: {integrity: sha512-xm+hzi9BsmhkDUGuyAWIydOAWer7Cs9cj8FM0t4HXaQ+qCubprT6wJZSKUxuvFJIUsIOqk1xXFaJzGJGnWtKMg==}
+  '@expressive-code/plugin-line-numbers@0.41.3':
+    resolution: {integrity: sha512-eig82a4CRC3XgVPQ2S/TMDcLiHJokOCD/mAdNVImpD3segVewxfjGgtj5DXQRo0E0q6f0R0EH34YzTFl5CEPqg==}
 
   '@expressive-code/plugin-shiki@0.41.3':
     resolution: {integrity: sha512-RlTARoopzhFJIOVHLGvuXJ8DCEme/hjV+ZnRJBIxzxsKVpGPW4Oshqg9xGhWTYdHstTsxO663s0cdBLzZj9TQA==}
-
-  '@expressive-code/plugin-text-markers@0.35.6':
-    resolution: {integrity: sha512-/k9eWVZSCs+uEKHR++22Uu6eIbHWEciVHbIuD8frT8DlqTtHYaaiwHPncO6KFWnGDz5i/gL7oyl6XmOi/E6GVg==}
 
   '@expressive-code/plugin-text-markers@0.41.3':
     resolution: {integrity: sha512-SN8tkIzDpA0HLAscEYD2IVrfLiid6qEdE9QLlGVSxO1KEw7qYvjpbNBQjUjMr5/jvTJ7ys6zysU2vLPHE0sb2g==}
@@ -2067,11 +2049,6 @@ packages:
     resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
     hasBin: true
 
-  astro-expressive-code@0.35.6:
-    resolution: {integrity: sha512-1U4KrvFuodaCV3z4I1bIR16SdhQlPkolGsYTtiANxPZUVv/KitGSCTjzksrkPonn1XuwVqvnwmUUVzTLWngnBA==}
-    peerDependencies:
-      astro: ^4.0.0-beta || ^3.3.0
-
   astro-expressive-code@0.41.3:
     resolution: {integrity: sha512-u+zHMqo/QNLE2eqYRCrK3+XMlKakv33Bzuz+56V1gs8H0y6TZ0hIi3VNbIxeTn51NLn+mJfUV/A0kMNfE4rANw==}
     peerDependencies:
@@ -2712,9 +2689,6 @@ packages:
   express@5.1.0:
     resolution: {integrity: sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==}
     engines: {node: '>= 18'}
-
-  expressive-code@0.35.6:
-    resolution: {integrity: sha512-+mx+TPTbMqgo0mL92Xh9QgjW0kSQIsEivMgEcOnaqKqL7qCw8Vkqc5Rg/di7ZYw4aMUSr74VTc+w8GQWu05j1g==}
 
   expressive-code@0.41.3:
     resolution: {integrity: sha512-YLnD62jfgBZYrXIPQcJ0a51Afv9h8VlWqEGK9uU2T5nL/5rb8SnA86+7+mgCZe5D34Tff5RNEA5hjNVJYHzrFg==}
@@ -4051,9 +4025,6 @@ packages:
 
   rehype-autolink-headings@7.1.0:
     resolution: {integrity: sha512-rItO/pSdvnvsP4QRB1pmPiNHUskikqtPojZKJPPPAVx9Hj8i8TwMBhofrrAYRhYOOBZH9tgmG5lPqDLuIWPWmw==}
-
-  rehype-expressive-code@0.35.6:
-    resolution: {integrity: sha512-pPdE+pRcRw01kxMOwHQjuRxgwlblZt5+wAc3w2aPGgmcnn57wYjn07iKO7zaznDxYVxMYVvYlnL+R3vWFQS4Gw==}
 
   rehype-expressive-code@0.41.3:
     resolution: {integrity: sha512-8d9Py4c/V6I/Od2VIXFAdpiO2kc0SV2qTJsRAaqSIcM9aruW4ASLNe2kOEo1inXAAkIhpFzAHTc358HKbvpNUg==}
@@ -5706,18 +5677,6 @@ snapshots:
   '@esbuild/win32-x64@0.25.10':
     optional: true
 
-  '@expressive-code/core@0.35.6':
-    dependencies:
-      '@ctrl/tinycolor': 4.2.0
-      hast-util-select: 6.0.4
-      hast-util-to-html: 9.0.5
-      hast-util-to-text: 4.0.2
-      hastscript: 9.0.1
-      postcss: 8.5.6
-      postcss-nested: 6.2.0(postcss@8.5.6)
-      unist-util-visit: 5.0.0
-      unist-util-visit-parents: 6.0.1
-
   '@expressive-code/core@0.40.2':
     dependencies:
       '@ctrl/tinycolor': 4.2.0
@@ -5742,17 +5701,9 @@ snapshots:
       unist-util-visit: 5.0.0
       unist-util-visit-parents: 6.0.1
 
-  '@expressive-code/plugin-collapsible-sections@0.35.6':
-    dependencies:
-      '@expressive-code/core': 0.35.6
-
   '@expressive-code/plugin-collapsible-sections@0.41.3':
     dependencies:
       '@expressive-code/core': 0.41.3
-
-  '@expressive-code/plugin-frames@0.35.6':
-    dependencies:
-      '@expressive-code/core': 0.35.6
 
   '@expressive-code/plugin-frames@0.40.2':
     dependencies:
@@ -5762,23 +5713,14 @@ snapshots:
     dependencies:
       '@expressive-code/core': 0.41.3
 
-  '@expressive-code/plugin-line-numbers@0.35.6':
+  '@expressive-code/plugin-line-numbers@0.41.3':
     dependencies:
-      '@expressive-code/core': 0.35.6
-
-  '@expressive-code/plugin-shiki@0.35.6':
-    dependencies:
-      '@expressive-code/core': 0.35.6
-      shiki: 1.29.2
+      '@expressive-code/core': 0.41.3
 
   '@expressive-code/plugin-shiki@0.41.3':
     dependencies:
       '@expressive-code/core': 0.41.3
       shiki: 3.13.0
-
-  '@expressive-code/plugin-text-markers@0.35.6':
-    dependencies:
-      '@expressive-code/core': 0.35.6
 
   '@expressive-code/plugin-text-markers@0.41.3':
     dependencies:
@@ -6678,8 +6620,8 @@ snapshots:
     dependencies:
       '@astrojs/mdx': 3.1.9(astro@4.16.19(@types/node@20.19.19)(rollup@4.52.4)(typescript@5.9.3))
       '@astrojs/react': 3.6.3(@types/node@20.19.19)(@types/react-dom@18.3.1)(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@expressive-code/plugin-collapsible-sections': 0.35.6
-      '@expressive-code/plugin-line-numbers': 0.35.6
+      '@expressive-code/plugin-collapsible-sections': 0.41.3
+      '@expressive-code/plugin-line-numbers': 0.41.3
       '@nanostores/react': 0.7.2(nanostores@0.10.3)(react@18.3.1)
       '@stackblitz/sdk': 1.11.0
       '@tutorialkit/react': file:../../oss/tutorialkit/packages/react(@types/react-dom@18.3.1)(@types/react@18.3.25)(postcss@8.5.6)(react-dom@18.3.1(react@18.3.1))(vite@6.3.6(@types/node@20.19.19)(jiti@2.6.1)(yaml@2.8.1))
@@ -6690,7 +6632,7 @@ snapshots:
       '@unocss/reset': 66.5.2
       '@webcontainer/api': 1.5.1
       astro: 4.16.19(@types/node@20.19.19)(rollup@4.52.4)(typescript@5.9.3)
-      astro-expressive-code: 0.35.6(astro@4.16.19(@types/node@20.19.19)(rollup@4.52.4)(typescript@5.9.3))
+      astro-expressive-code: 0.41.3(astro@4.16.19(@types/node@20.19.19)(rollup@4.52.4)(typescript@5.9.3))
       chokidar: 3.6.0
       fast-glob: 3.3.3
       front-matter: 4.0.2
@@ -7443,11 +7385,6 @@ snapshots:
 
   astring@1.9.0: {}
 
-  astro-expressive-code@0.35.6(astro@4.16.19(@types/node@20.19.19)(rollup@4.52.4)(typescript@5.9.3)):
-    dependencies:
-      astro: 4.16.19(@types/node@20.19.19)(rollup@4.52.4)(typescript@5.9.3)
-      rehype-expressive-code: 0.35.6
-
   astro-expressive-code@0.41.3(astro@4.16.19(@types/node@20.19.19)(rollup@4.52.4)(typescript@5.9.3)):
     dependencies:
       astro: 4.16.19(@types/node@20.19.19)(rollup@4.52.4)(typescript@5.9.3)
@@ -8196,13 +8133,6 @@ snapshots:
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
-
-  expressive-code@0.35.6:
-    dependencies:
-      '@expressive-code/core': 0.35.6
-      '@expressive-code/plugin-frames': 0.35.6
-      '@expressive-code/plugin-shiki': 0.35.6
-      '@expressive-code/plugin-text-markers': 0.35.6
 
   expressive-code@0.41.3:
     dependencies:
@@ -9902,10 +9832,6 @@ snapshots:
       hast-util-is-element: 3.0.0
       unified: 11.0.5
       unist-util-visit: 5.0.0
-
-  rehype-expressive-code@0.35.6:
-    dependencies:
-      expressive-code: 0.35.6
 
   rehype-expressive-code@0.41.3:
     dependencies:

--- a/styles/global.css
+++ b/styles/global.css
@@ -67,7 +67,7 @@
     farthest-corner circle at 50% -19% in oklch decreasing hue,
     var(--amv-highlight) 12%,
     14%,
-    oklch(0.9702 0 0) 51%
+    oklch(0.9702 0 0) 30%
   );
 }
 

--- a/theme.css
+++ b/theme.css
@@ -202,10 +202,10 @@ view-toggle {
   );
   --tk-elements-editor-gutter-activeLineTextColor: theme('colors.bgr.500');
 
-  --av-ec-collapsibleSections-closed-bgColor: theme('colors.bgr.100');
-  --av-ec-collapsibleSections-closed-textColor: theme('colors.bgr.400');
-  --av-ec-collapsibleSections-open-bgColor: var(
-    --av-ec-collapsibleSections-closed-bgColor
+  --av-ec-collapsibleSections-closedBackgroundColor: theme('colors.bgr.100');
+  --av-ec-collapsibleSections-closedTextColor: theme('colors.bgr.400');
+  --av-ec-collapsibleSections-openBackgroundColorCollapsible: var(
+    --av-ec-collapsibleSections-closedBackgroundColor
   );
 
   --av-ec-frames-tooltipSuccessBackground: theme('colors.positive');

--- a/theme.css
+++ b/theme.css
@@ -201,6 +201,15 @@ view-toggle {
     --tk-elements-editor-backgroundColor
   );
   --tk-elements-editor-gutter-activeLineTextColor: theme('colors.bgr.500');
+
+  --av-ec-collapsibleSections-closed-bgColor: theme('colors.bgr.100');
+  --av-ec-collapsibleSections-closed-textColor: theme('colors.bgr.400');
+  --av-ec-collapsibleSections-open-bgColor: var(
+    --av-ec-collapsibleSections-closed-bgColor
+  );
+
+  --av-ec-frames-tooltipSuccessBackground: theme('colors.positive');
+  --av-ec-frames-tooltipSuccessForeground: theme('colors.bgr.dark');
 }
 
 /* Color Tokens Dark */
@@ -304,6 +313,15 @@ view-toggle {
     --tk-elements-editor-backgroundColor
   );
   --tk-elements-editor-gutter-activeLineTextColor: theme('colors.bgr.300');
+
+  --av-ec-collapsibleSections-closedBackgroundColor: theme('colors.bgr.800');
+  --av-ec-collapsibleSections-closedTextColor: theme('colors.bgr.500');
+  --av-ec-collapsibleSections-openBackgroundColorCollapsible: var(
+    --av-ec-collapsibleSections-closedBackgroundColor
+  );
+
+  --av-ec-frames-tooltipSuccessBackground: theme('colors.positive');
+  --av-ec-frames-tooltipSuccessForeground: theme('colors.bgr');
 }
 
 /*
@@ -976,7 +994,7 @@ view-toggle {
     farthest-corner circle at 50% -19% in oklch decreasing hue,
     var(--amv-highlight) 12%,
     14%,
-    oklch(0.9702 0 0) 51%
+    oklch(0.9702 0 0) 30%
   );
 }
 


### PR DESCRIPTION
This required to update tutorialkit to allow for the styles to be applied properly. See https://github.com/ackzell/tutorialkit/commit/ac9e3a4dbc49d1a5fc17ea4e4d89b61eebd08532

<img width="1529" height="951" alt="image" src="https://github.com/user-attachments/assets/ecfaf957-e560-470d-8efa-4b57a364cd21" />

<img width="1529" height="951" alt="image" src="https://github.com/user-attachments/assets/db1b041f-3a94-43f0-9fb2-c8f02c2fedac" />

<img width="1599" height="1085" alt="image" src="https://github.com/user-attachments/assets/3190343e-c4aa-49e9-a3fe-38f9d078b8ca" />

<img width="1599" height="1085" alt="image" src="https://github.com/user-attachments/assets/bb55205b-a45d-4bab-a1b4-584e5fdb529b" />
